### PR TITLE
support any RedisURI by using their URI parser if the url is parsable by RedisURI

### DIFF
--- a/src/main/java/services/moleculer/util/redis/RedisGetSetClient.java
+++ b/src/main/java/services/moleculer/util/redis/RedisGetSetClient.java
@@ -350,6 +350,15 @@ public final class RedisGetSetClient {
 		ArrayList<RedisURI> list = new ArrayList<>(urls.length);
 		for (String url : urls) {
 			url = url.trim();
+			
+			try {
+				list.add(RedisURI.create(url));
+				continue;
+			}
+			catch (IllegalArgumentException e) {
+				// ignore, use old parsing below.
+			}
+
 			if (url.startsWith("redis://")) {
 				url = url.substring(8);
 			}


### PR DESCRIPTION
This exposes the ability to use sentinel via urls, as per the RedisURI docs, of the form : 

redis-sentinel://[password@]host1 [: port1][, host2 [:port2]][, hostN [:portN]][/ database][? [timeout=timeout[d|h|m|s|ms|us|ns]] [ &sentinelMasterId=sentinelMasterId] [&database=database] [&clientName=clientName]]